### PR TITLE
FCMS-11: Prevent re-use of encrypted JSON

### DIFF
--- a/src/main/java/org/glyptodon/guacamole/auth/json/JSONAuthenticationProviderModule.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/JSONAuthenticationProviderModule.java
@@ -27,6 +27,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.glyptodon.guacamole.auth.json.user.UserDataService;
 
 /**
  * Guice module which configures injections specific to the JSON authentication
@@ -80,6 +81,7 @@ public class JSONAuthenticationProviderModule extends AbstractModule {
         bind(ConfigurationService.class);
         bind(CryptoService.class);
         bind(RequestValidationService.class);
+        bind(UserDataService.class);
 
     }
 

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserData.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserData.java
@@ -49,6 +49,13 @@ public class UserData {
     private Long expires;
 
     /**
+     * Whether this data can only be used once. If set to true, reuse of the
+     * associated signed data will not be allowed. This is only valid if the
+     * expiration timestamp has been set.
+     */
+    private boolean singleUse = false;
+
+    /**
      * All connections accessible by this user. The key of each entry is both
      * the connection identifier and the connection name.
      */
@@ -219,6 +226,33 @@ public class UserData {
      */
     public void setExpires(Long expires) {
         this.expires = expires;
+    }
+
+    /**
+     * Returns whether this user data is intended for single-use only.
+     * Single-use data cannot be used more than once. This flag only has
+     * meaning if the data also has an expires timestamp.
+     *
+     * @return
+     *     true if this data is intended for single-use only, false
+     *     otherwise.
+     */
+    public boolean isSingleUse() {
+        return singleUse;
+    }
+
+    /**
+     * Sets whether this user data is intended for single-use only. Single-use
+     * data cannot be used more than once. This flag only has meaning if the
+     * data also has an expires timestamp. By default, user data is NOT
+     * single-use.
+     *
+     * @param singleUse
+     *     true if this data is intended for single-use only, false
+     *     otherwise.
+     */
+    public void setSingleUse(boolean singleUse) {
+        this.singleUse = singleUse;
     }
 
     /**

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataBlacklist.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataBlacklist.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016 Glyptodon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.auth.json.user;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.xml.bind.DatatypeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Atomic blacklist of UserData objects, stored by their associated
+ * cryptographic signatures. UserData objects stored within this blacklist MUST
+ * have an associated expiration timestamp, and will automatically be removed
+ * from the blacklist once they have expired.
+ *
+ * @author Michael Jumper
+ */
+public class UserDataBlacklist {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(UserDataBlacklist.class);
+
+    /**
+     * All blacklisted UserData objects, stored by their associated
+     * cryptographic signatures. NOTE: Each key into this map is the hex
+     * string produced by encoding the binary signature using DatatypeConverter.
+     * A byte[] cannot be used directly.
+     */
+    private final ConcurrentMap<String, UserData> blacklist =
+            new ConcurrentHashMap<String, UserData>();
+
+    /**
+     * Removes all expired UserData objects from the blacklist. This will
+     * automatically be invoked whenever new UserData is added to the blacklist.
+     */
+    public void removeExpired() {
+
+        // Remove expired data from blacklist
+        Iterator<Map.Entry<String, UserData>> current = blacklist.entrySet().iterator();
+        while (current.hasNext()) {
+
+            // Remove entry from map if its associated with expired data
+            Map.Entry<String, UserData> entry = current.next();
+            if (entry.getValue().isExpired())
+                current.remove();
+            
+        }
+
+    }
+
+    /**
+     * Adds the given UserData to the blacklist, storing it according to the
+     * provided cryptographic signature. The UserData MUST have an associated
+     * expiration timestamp. If any UserData objects already within the
+     * blacklist have expired, they will automatically be removed when this
+     * function is invoked.
+     *
+     * @param data
+     *     The UserData to store within the blacklist.
+     *
+     * @param signature
+     *     The cryptographic signature associated with the UserData.
+     *
+     * @return
+     *     true if the UserData was not already blacklisted and has
+     *     successfully been added, false otherwise.
+     */
+    public boolean add(UserData data, byte[] signature) {
+
+        // Expiration timestamps must be provided
+        if (data.getExpires() == null) {
+            logger.warn("An expiration timestamp MUST be provided for "
+                    + "single-use data.");
+            return false;
+        }
+
+        // Remove any expired entries
+        removeExpired();
+
+        // Expired user data is implicitly blacklisted
+        if (data.isExpired())
+            return false;
+
+        // Add to blacklist only if not already present
+        String signatureHex = DatatypeConverter.printHexBinary(signature);
+        return blacklist.putIfAbsent(signatureHex, data) == null;
+
+    }
+
+}

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
@@ -23,6 +23,7 @@
 package org.glyptodon.guacamole.auth.json.user;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
@@ -54,6 +55,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Michael Jumper
  */
+@Singleton
 public class UserDataService {
 
     /**


### PR DESCRIPTION
This change adds a new `singleUse` property at the top level of the `UserData` object. When specified, the signature of that particular `UserData` object is added to a blacklist until the underlying data expires, and any future attempt to use that same data will fail. The blacklist is automatically cleaned of expired data each time a signature is added.

This new flag is analogous to the existing `singleUse` property available at the connection level, which allows a particular connection to be connected to only once.