### PR TITLE
EESM-14: Add support for connection sharing/shadowing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,29 @@ Property name | Type     | Description
 `expires`     | `number` | The absolute time after which the JSON should no longer be accepted, even if the signature is valid, as a standard UNIX epoch timestamp with millisecond resolution (the number of milliseconds since midnight of January 1, 1970 UTC).
 `connections` | `object` | The set of connections which should be exposed to the user by their corresponding, unique names. If no connections will be exposed to the user, this can simply be an empty object (`{}`).
 
-Each connection defined within each submitted JSON object has the following
-properties:
+Each normal connection defined within each submitted JSON object has the
+following properties:
 
 Property name | Type     | Description
 --------------|----------|------------
+`id`          | `string` | An optional opaque value which uniquely identifies this connection across all other connections which may be active at any given time. This property is only required if you wish to allow the connection to be shared or shadowed.
 `protocol`    | `string` | The internal name of a supported protocol, such as `vnc`, `rdp`, or `ssh`.
 `parameters`  | `object` | An object representing the connection parameter name/value pairs to apply to the connection, as documented in the [Guacamole manual](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#connection-configuration).
+
+Connections which share or shadow other connections use a `join` property
+instead of a `protocol` property, where `join` contains the value of the `id`
+property of the connection being joined:
+
+Property name | Type     | Description
+--------------|----------|------------
+`id`          | `string` | An optional opaque value which uniquely identifies this connection across all other connections which may be active at any given time. This property is only required if you wish to allow the connection to be shared or shadowed. (Yes, a connection which shadows another connection may itself be shadowed.)
+`join`        | `string` | The opaque ID given within the `id` property of the connection being joined (shared / shadowed).
+`parameters`  | `object` | An object representing the connection parameter name/value pairs to apply to the connection, as documented in the [Guacamole manual](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#connection-configuration). Most of the connection configuration is inherited from the connection being joined. In general, the only property relevant to joining connections is `read-only`.
+
+If a connection is configured to join another connection, that connection will
+only be usable if the connection being joined is currently active. If two
+connections are established having the same `id` value, only the last
+connection will be joinable using the given `id`.
 
 Generating encrypted JSON
 -------------------------

--- a/src/main/java/org/glyptodon/guacamole/auth/json/JSONAuthenticationProviderModule.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/JSONAuthenticationProviderModule.java
@@ -27,6 +27,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.glyptodon.guacamole.auth.json.connection.ConnectionService;
 import org.glyptodon.guacamole.auth.json.user.UserDataService;
 
 /**
@@ -79,6 +80,7 @@ public class JSONAuthenticationProviderModule extends AbstractModule {
 
         // Bind JSON-specific services
         bind(ConfigurationService.class);
+        bind(ConnectionService.class);
         bind(CryptoService.class);
         bind(RequestValidationService.class);
         bind(UserDataService.class);

--- a/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
@@ -51,9 +51,13 @@ package org.glyptodon.guacamole.auth.json.connection;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
+import org.apache.guacamole.io.GuacamoleReader;
+import org.apache.guacamole.io.GuacamoleWriter;
 import org.apache.guacamole.net.GuacamoleSocket;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.InetGuacamoleSocket;
@@ -64,6 +68,8 @@ import org.apache.guacamole.protocol.ConfiguredGuacamoleSocket;
 import org.apache.guacamole.protocol.GuacamoleClientInformation;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
 import org.glyptodon.guacamole.auth.json.user.UserData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service which provides a centralized means of establishing connections,
@@ -75,10 +81,24 @@ import org.glyptodon.guacamole.auth.json.user.UserData;
 public class ConnectionService {
 
     /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ConnectionService.class);
+
+    /**
      * The Guacamole server environment.
      */
     @Inject
     private Environment environment;
+
+    /**
+     * Mapping of the unique IDs of active connections (as specified within the
+     * UserData.Connection object) to the underlying connection ID (as returned
+     * via the Guacamole protocol handshake). Only connections with defined IDs
+     * are tracked here.
+     */
+    private final ConcurrentHashMap<String, String> activeConnections =
+            new ConcurrentHashMap<String, String>();
 
     /**
      * Generates a new GuacamoleConfiguration from the associated protocol and
@@ -94,9 +114,25 @@ public class ConnectionService {
      */
     public GuacamoleConfiguration getConfiguration(UserData.Connection connection) {
 
-        // Create new configuration for given protocol
         GuacamoleConfiguration config = new GuacamoleConfiguration();
-        config.setProtocol(connection.getProtocol());
+
+        // Set connection ID if joining an active connection
+        String primaryConnection = connection.getPrimaryConnection();
+        if (primaryConnection != null) {
+
+            // If no such active connection actually exists, allow things to
+            // fail cleanly by using a non-existent connection ID
+            String id = activeConnections.get(primaryConnection);
+            if (id == null)
+                id = UUID.randomUUID().toString();
+
+            config.setConnectionID(id);
+
+        }
+
+        // Otherwise, require protocol
+        else
+            config.setProtocol(connection.getProtocol());
 
         // Add all parameter name/value pairs
         Map<String, String> parameters = connection.getParameters();
@@ -136,7 +172,7 @@ public class ConnectionService {
         String hostname = proxyConfig.getHostname();
         int port = proxyConfig.getPort();
 
-        GuacamoleSocket socket;
+        final ConfiguredGuacamoleSocket socket;
 
         // Determine socket type based on required encryption method
         switch (proxyConfig.getEncryptionMethod()) {
@@ -163,7 +199,47 @@ public class ConnectionService {
 
         }
 
-        return new SimpleGuacamoleTunnel(socket);
+        // If the current connection is not being tracked (no ID) just return
+        // a normal, non-tracking tunnel
+        final String id = connection.getId();
+        if (id == null)
+            return new SimpleGuacamoleTunnel(socket);
+
+        // If the current connection is intended to be tracked (an ID was
+        // provided), but a connection is already in progress with that ID,
+        // log a warning that the original connection will no longer be tracked
+        final String connectionID = socket.getConnectionID();
+        String activeConnection = activeConnections.put(id, connectionID);
+        if (activeConnection != null)
+            logger.warn("A connection with ID \"{}\" is already in progress, "
+                    + "but another attempt to use this ID has been made. The "
+                    + "original connection will no longer be joinable.", id);
+
+        // Return a tunnel which automatically tracks the active connection
+        return new SimpleGuacamoleTunnel(new GuacamoleSocket() {
+
+            @Override
+            public GuacamoleReader getReader() {
+                return socket.getReader();
+            }
+
+            @Override
+            public GuacamoleWriter getWriter() {
+                return socket.getWriter();
+            }
+
+            @Override
+            public void close() throws GuacamoleException {
+                activeConnections.remove(id, connectionID);
+                socket.close();
+            }
+
+            @Override
+            public boolean isOpen() {
+                return socket.isOpen();
+            }
+
+        });
 
     }
 

--- a/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2018 Glyptodon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * NOTE: The code implemented provided here for establishing connections is
+ * based upon the connect() function of the SimpleConnection class, part of the
+ * "guacamole-ext" library, which is part of Apache Guacamole. The relevant
+ * code has been modified to suit the purposes of this extension.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.glyptodon.guacamole.auth.json.connection;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Map;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.environment.Environment;
+import org.apache.guacamole.net.GuacamoleSocket;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.net.InetGuacamoleSocket;
+import org.apache.guacamole.net.SSLGuacamoleSocket;
+import org.apache.guacamole.net.SimpleGuacamoleTunnel;
+import org.apache.guacamole.net.auth.GuacamoleProxyConfiguration;
+import org.apache.guacamole.protocol.ConfiguredGuacamoleSocket;
+import org.apache.guacamole.protocol.GuacamoleClientInformation;
+import org.apache.guacamole.protocol.GuacamoleConfiguration;
+import org.glyptodon.guacamole.auth.json.user.UserData;
+
+/**
+ * Service which provides a centralized means of establishing connections,
+ * tracking/joining active connections, and retrieving associated data.
+ *
+ * @author Michael Jumper
+ */
+@Singleton
+public class ConnectionService {
+
+    /**
+     * The Guacamole server environment.
+     */
+    @Inject
+    private Environment environment;
+
+    /**
+     * Generates a new GuacamoleConfiguration from the associated protocol and
+     * parameters of the given UserData.Connection.
+     *
+     * @param connection
+     *     The UserData.Connection whose protocol and parameters should be used
+     *     to construct the new GuacamoleConfiguration.
+     *
+     * @return
+     *     A new GuacamoleConfiguration generated from the associated protocol
+     *     and parameters of the given UserData.Connection.
+     */
+    public GuacamoleConfiguration getConfiguration(UserData.Connection connection) {
+
+        // Create new configuration for given protocol
+        GuacamoleConfiguration config = new GuacamoleConfiguration();
+        config.setProtocol(connection.getProtocol());
+
+        // Add all parameter name/value pairs
+        Map<String, String> parameters = connection.getParameters();
+        if (parameters != null)
+            config.setParameters(parameters);
+
+        return config;
+
+    }
+
+    /**
+     * Establishes a connection to guacd using the information associated with
+     * the given connection object. The resulting connection will be provided
+     * the given client information during the Guacamole protocol handshake.
+     *
+     * @param connection
+     *     The connection object describing the nature of the connection to be
+     *     established.
+     *
+     * @param info
+     *     Information associated with the connecting client.
+     *
+     * @return
+     *     A fully-established GuacamoleTunnel.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while connecting to guacd, or if permission to
+     *     connect is denied.
+     */
+    public GuacamoleTunnel connect(UserData.Connection connection,
+            GuacamoleClientInformation info) throws GuacamoleException {
+
+        // Retrieve proxy configuration from environment
+        GuacamoleProxyConfiguration proxyConfig = environment.getDefaultGuacamoleProxyConfiguration();
+
+        // Get guacd connection parameters
+        String hostname = proxyConfig.getHostname();
+        int port = proxyConfig.getPort();
+
+        GuacamoleSocket socket;
+
+        // Determine socket type based on required encryption method
+        switch (proxyConfig.getEncryptionMethod()) {
+
+            // If guacd requires SSL, use it
+            case SSL:
+                socket = new ConfiguredGuacamoleSocket(
+                    new SSLGuacamoleSocket(hostname, port),
+                    getConfiguration(connection), info
+                );
+                break;
+
+            // Connect directly via TCP if encryption is not enabled
+            case NONE:
+                socket = new ConfiguredGuacamoleSocket(
+                    new InetGuacamoleSocket(hostname, port),
+                    getConfiguration(connection), info
+                );
+                break;
+
+            // Abort if encryption method is unknown
+            default:
+                throw new GuacamoleServerException("Unimplemented encryption method.");
+
+        }
+
+        return new SimpleGuacamoleTunnel(socket);
+
+    }
+
+}

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserData.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserData.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * All data associated with a particular user, as parsed from the JSON supplied
@@ -70,9 +71,23 @@ public class UserData {
     public static class Connection {
 
         /**
+         * An arbitrary, opaque, unique ID for this connection. If specified
+         * via the "join" (primaryConnection) property of another connection,
+         * that connection may be used to join this connection.
+         */
+        private String id;
+
+        /**
          * The protocol that this connection should use, such as "vnc" or "rdp".
          */
         private String protocol;
+
+        /**
+         * The opaque ID of the connection being joined (shared), as given with
+         * the "id" property. If specified, the provided protocol is ignored.
+         * This value is exposed via the "join" property within JSON.
+         */
+        private String primaryConnection;
 
         /**
          * Map of all connection parameter values, where each key is the parameter
@@ -89,6 +104,32 @@ public class UserData {
          * immediately upon use.
          */
         private boolean singleUse = false;
+
+        /**
+         * Returns an arbitrary, opaque, unique ID for this connection. If
+         * defined, this ID may be used via the "join" (primaryConnection)
+         * property of another connection to join (share) this connection while
+         * it is in progress.
+         *
+         * @return
+         *    An arbitrary, opaque, unique ID for this connection.
+         */
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * Sets an arbitrary, opaque ID which uniquely identifies this
+         * connection. This ID may be used via the "join" (primaryConnection)
+         * property of another connection to join (share) this connection while
+         * it is in progress.
+         *
+         * @param id
+         *    An arbitrary, opaque, unique ID for this connection.
+         */
+        public void setId(String id) {
+            this.id = id;
+        }
 
         /**
          * Returns the protocol that this connection should use, such as "vnc"
@@ -110,6 +151,32 @@ public class UserData {
          */
         public void setProtocol(String protocol) {
             this.protocol = protocol;
+        }
+
+        /**
+         * Returns the opaque ID of the connection being joined (shared), if
+         * any. If specified, any provided protocol is ignored. This value is
+         * exposed via the "join" property within JSON.
+         *
+         * @return
+         *     The opaque ID of the connection being joined (shared), if any.
+         */
+        @JsonProperty("join")
+        public String getPrimaryConnection() {
+            return primaryConnection;
+        }
+
+        /**
+         * Sets the opaque ID of the connection being joined (shared). If
+         * specified, any provided protocol is ignored. This is exposed via the
+         * "join" property within JSON.
+         *
+         * @param primaryConnection
+         *     The opaque ID of the connection being joined (shared).
+         */
+        @JsonProperty("join")
+        public void setPrimaryConnection(String primaryConnection) {
+            this.primaryConnection = primaryConnection;
         }
 
         /**

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataConnection.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataConnection.java
@@ -132,7 +132,15 @@ public class UserDataConnection implements Connection {
 
     @Override
     public GuacamoleConfiguration getConfiguration() {
-        return connectionService.getConfiguration(connection);
+
+        // Generate configuration, using a skeleton configuration if generation
+        // fails
+        GuacamoleConfiguration config = connectionService.getConfiguration(connection);
+        if (config == null)
+            config = new GuacamoleConfiguration();
+
+        return config;
+
     }
 
     @Override

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
@@ -369,9 +369,6 @@ public class UserDataService {
                 connection
             );
 
-            // All connections are within the root group
-            guacConnection.setParentIdentifier(ROOT_CONNECTION_GROUP);
-
             // Add corresponding Connection to directory
             directoryContents.put(identifier, guacConnection);
 

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataService.java
@@ -23,6 +23,7 @@
 package org.glyptodon.guacamole.auth.json.user;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -91,6 +92,12 @@ public class UserDataService {
      */
     @Inject
     private CryptoService cryptoService;
+
+    /**
+     * Provider for UserDataConnection instances.
+     */
+    @Inject
+    private Provider<UserDataConnection> userDataConnectionProvider;
 
     /**
      * The identifier reserved for the root connection group.
@@ -356,7 +363,7 @@ public class UserDataService {
 
             // Create Guacamole connection containing the defined identifier
             // and parameters
-            Connection guacConnection = new UserDataConnection(
+            Connection guacConnection = userDataConnectionProvider.get().init(
                 userData,
                 identifier,
                 connection


### PR DESCRIPTION
These changes add two additional properties to the JSON accepted by this extension: `id`, an arbitrary and opaque value which uniquely identifies a connection such that it may be joined later, and `join`, which points to the connection being joined by its `id` value.

These identifier values are opaque and strictly internal, used only as a means of declaring the linkage between connections. They are not exposed externally via REST.

For example, if access to a VNC connection was given with the following JSON:

```json
{
    "connections" : {
        "Human-readable display name" : {
            "id" : "someUniqueId",
            "protocol" : "vnc",
            "parameters" : {
                "hostname" : "somehost",
                "port" : "5901"
            }
        }
    }
}
```

then access to shadow that connection can be given with the following JSON:

```json
{
    "connections" : {
        "Human-readable display name for shadow connection" : {
            "join" : "someUniqueId",
            "parameters" : {
                "read-only" : "true"
            }
        }
    }
}
```

The connection joining another connection can even have its own unique `id` value, allowing it to be independently joined:

```json
{
    "connections" : {
        "Human-readable display name for shadow connection" : {
            "id" : "someOtherUniqueId",
            "join" : "someUniqueId",
            "parameters" : {
                "read-only" : "true"
            }
        }
    }
}
```

It is intended that these IDs are unique across all connections, however it is also documented behavior that connections which have the same ID will continue to function. If two connections are established having the same ID, only the last connection will remain joinable by that ID.

Similar to the connection sharing semantics implemented by Apache Guacamole's database authentication, a connection which joins another connection is automatically closed when the joined connection terminates.