### PR TITLE
Add support for guacamole paramater tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,20 @@ For example, if you have a file called `auth.json` containing the following:
                 "protocol" : "rdp",
                 "parameters" : {
                     "hostname" : "10.10.209.63",
-                    "port" : "3389"
+                    "port" : "3389",
+                    "ignore-cert": "true",
+                    "recording-path": "/recordings",
+                    "recording-name": "My-Connection-${GUAC_USERNAME}-${GUAC_DATE}-${GUAC_TIME}"
                 }
             },
             "My OTHER Connection" : {
                 "protocol" : "rdp",
                 "parameters" : {
                     "hostname" : "10.10.209.64",
-                    "port" : "3389"
+                    "port" : "3389",
+                    "ignore-cert": "true",
+                    "recording-path": "/recordings",
+                    "recording-name": "My-OTHER-Connection-${GUAC_USERNAME}-${GUAC_DATE}-${GUAC_TIME}"
                 }
             }
         }
@@ -170,17 +176,22 @@ and you run:
 
 You will receive the following output:
 
-    le2Ug6YIo4perD2GV17QtWvOdfSemVDDtCOdRYJlbdUf3fhN+63LpQa1RDkzU7Zc
-    DW3+OtyTCBGQ7OLO+HpG6pHNom76BXpmnHSRx1UdQ3WVZelPUXEDzxe74aN6DUP9
-    G9isXhBMdLUhZwEJf4k4Gpzt9MHAH5PufSKq3DO1UHnrRjdGbKKddug2BcuDrwJM
-    UJf1tRX9CAEC11/gWEwrHDOhH/abeyeDyElbaEG/oOY8EdoFNYgUsjI2x31OpCuB
-    sEv7FOFafL05wEoIFv0/pPft0DHk7GuvHBBCqXuK98yMEo3d0zD5D+IsOY8Rmm1+
-    0CoWkX22mqyRQMFS2fTp/fClCN4QLb0aNn+unweTimd2SXN9cjREmZknXf7Tj8oU
-    /FNXc37i0HEfG5aVgp5znMCwwRAOFnFhLqG3K2yaTRE+hLNBxltIjLfFmNG5TZZA
-    gUdKyuegsOd0KS5iHdW6tPI01AwfRO9y2z20t3flsgDp50EGWjT2/TTA5Nkjnnjk
-    JXNzCOfM7DCI/ioEz6Ga140qXfOX/g8SGiukpwt+j0ANI573TdVt7nsp7MZX2qKg
-    2GcoNqjBqQxqpqI5ZYz4KVfD4cYu8KDZ9MiFMzbUwwKNSzYxiep1KJwiG0HQThHg
-    oX2FJYOFCFcinQgGkUOaBJK1K0bo1ouaBSe4iGPjd54=
+    A2Pf5Kpmm97I2DT1PifIrfU6q3yzoGcIbNXEd60WNangT8DAVjAl6luaqwhBJnCK
+    uqcf9ZZlRo3uDxTHvUM3eq1YvdghL0GbosOn8Mn38j2ydOMk+Cd15a8ggb4/ddt/
+    yIBK4DxrN7MNbouZ091KYtXC6m20E6sGzLy676BlMSg1cmsENRIihOynsSLSCvo0
+    diif6H7T+ZuIqF7B5SW+adGfMaHlfknlIvSpLGHhrIP4aMYE/ZU2vYNg8ez27sCS
+    wDBWu5lERtfCYFyU4ysjRU5Hyov+yKa+O7jcRYpw3N+fHbCg7/dxVNW07qNOKssv
+    pzUciGvDPUCPpa02WmPJNEBowwQireO1952/MNAI77cW2UepbljD/bwOiZl2THJz
+    LrENo7K5acimBa+EjWEesgn7lx/WTCF3zxR6TH1CWrQM8Et1aUK1Nf8K11xEQbTy
+    klyaNtCmTfyahRZ/fUPxDNrdJVpPOSELkf7RJO5tOdK/FFIFIbze3ZUyXgRq+pHY
+    owpgOmudDBTBlxhXiONdutRI/RZbFM/7GBMdmI8AR/401OCV3nsI4jLhukjMXH3V
+    f3pQg+xKMhi/QExHhDk8VTNYk7GurK4vgehn7HQ0oSGh8pGcmxB6W43cz+hyn6VQ
+    On6i90cSnIhRO8SysZt332LwJCDm7I+lBLaI8NVHU6bnAY1Axx5oH3YTKc4qzHls
+    HEAFYLkD6aHMvHkF3b798CMravjxiJV3m7hsXDbaFN6AFhn8GIkMRRrjuevfZ+q9
+    enWN14s24vt5OVg69DljzALobUNKUXFx69SR8EpSBvUcKq8s/OgbDpFvKbwsDY57
+    HGT4T0CuRIA0TGUI075uerKBNApVhuBA1BmWJIrI4JXw5MuX6pdBe+MYccO3vfo+
+    /frazj8rHdkDa/IbueMbvq+1ozV2+UuxrbaTrV2i4jSRgd74U0QzOh9e8Q0i7vOi
+    l3hnIfOfg+v1oULmZmJSeiAYWxeGvPptp+n7rNFqHGM=
 
 The resulting base64 data above, if submitted using the `data` parameter to
 Guacamole, will authenticate a user and grant them access to the connections

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-json</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-1</version>
+    <version>1.1.0-1</version>
     <name>guacamole-auth-json</name>
     <url>http://glyptodon.org/</url>
 
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/connection/ConnectionService.java
@@ -73,6 +73,7 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
 import org.glyptodon.guacamole.auth.json.user.UserData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.guacamole.token.TokenFilter;
 
 /**
  * Service which provides a centralized means of establishing connections,
@@ -196,7 +197,7 @@ public class ConnectionService {
      *     connect is denied.
      */
     public GuacamoleTunnel connect(UserData.Connection connection,
-            GuacamoleClientInformation info) throws GuacamoleException {
+            GuacamoleClientInformation info, Map<String, String> tokens) throws GuacamoleException {
 
         // Retrieve proxy configuration from environment
         GuacamoleProxyConfiguration proxyConfig = environment.getDefaultGuacamoleProxyConfiguration();
@@ -206,13 +207,17 @@ public class ConnectionService {
         int port = proxyConfig.getPort();
 
         // Generate and verify connection configuration
-        GuacamoleConfiguration config = getConfiguration(connection);
-        if (config == null) {
+        GuacamoleConfiguration filteredConfig = getConfiguration(connection);
+
+        if (filteredConfig == null) {
             logger.debug("Configuration for connection could not be "
                     + "generated. Perhaps the connection being joined is not "
                     + "active?");
             throw new GuacamoleResourceNotFoundException("No such connection");
         }
+
+        // Apply tokens to config parameters
+        new TokenFilter(tokens).filterValues(filteredConfig.getParameters());
 
         // Determine socket type based on required encryption method
         final ConfiguredGuacamoleSocket socket;
@@ -222,7 +227,7 @@ public class ConnectionService {
             case SSL:
                 socket = new ConfiguredGuacamoleSocket(
                     new SSLGuacamoleSocket(hostname, port),
-                    config, info
+                        filteredConfig, info
                 );
                 break;
 
@@ -230,7 +235,7 @@ public class ConnectionService {
             case NONE:
                 socket = new ConfiguredGuacamoleSocket(
                     new InetGuacamoleSocket(hostname, port),
-                    config, info
+                        filteredConfig, info
                 );
                 break;
 
@@ -307,7 +312,7 @@ public class ConnectionService {
 
         // Track tunnels which join connections, such that they can be
         // automatically closed when the joined connection closes
-        String joinedConnection = config.getConnectionID();
+        String joinedConnection = filteredConfig.getConnectionID();
         if (joinedConnection != null) {
 
             // Track shadower of joined connection if possible

--- a/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataConnection.java
+++ b/src/main/java/org/glyptodon/guacamole/auth/json/user/UserDataConnection.java
@@ -179,7 +179,7 @@ public class UserDataConnection implements Connection {
     }
 
     @Override
-    public GuacamoleTunnel connect(GuacamoleClientInformation info)
+    public GuacamoleTunnel connect(GuacamoleClientInformation info, Map<String, String> tokens)
             throws GuacamoleException {
 
         // Prevent future use immediately upon connect
@@ -192,7 +192,7 @@ public class UserDataConnection implements Connection {
         }
 
         // Perform connection operation
-        return connectionService.connect(connection, info);
+        return connectionService.connect(connection, info, tokens);
 
     }
 

--- a/src/main/resources/guac-manifest.json
+++ b/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.0.0",
+    "guacamoleVersion" : "1.1.0",
 
     "name"      : "Encrypted JSON Authentication",
     "namespace" : "guac-json",


### PR DESCRIPTION
Hello, just wanted to thank you for this project, we're trying it out and have discovered that parameterized tokens do not work on the latest version of guacamole.

This PR should update the guacamole-ext dependency to 1.2.0 and adds support for Paramater tokens.

