### PR TITLE
Automated releases & automatic tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,15 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B test --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  release:
+    types: [created]
+
+name: Handle Release
+jobs:
+  generate:
+    name: Create release-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+         repo_token: ${{ secrets.GITHUB_TOKEN }}
+         file: target/guacamole-auth-json-*.jar
+         tag: ${{ github.ref }}
+         file_glob: true
+         overwrite: true


### PR DESCRIPTION
Hi, I noticed (or couldn't find) a pre-compiled version of the .jar file to use to install the plugin. This PR creates automatic builds upon releases. Automated builds are fairly easy to configure and manage in github. I'm a fan of github actions especially since this is already hosted on github. 

These yaml files do a couple of different things:
1) Compile the build anytime someone makes a release and attaches the jar file to the release. It only runs when releases are created.
For an example see:
https://github.com/kudelskisecurity/guacamole-auth-json/releases/tag/test 

2) Runs `mvn test` on each commit that is made to the repository. While there are no unit tests... it at least ensures that the code will compile. 
